### PR TITLE
Patch setup.py to work on Darwin (osx)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 venv
 *.pyc
 *.swp
+
+build
+libarchive/__libarchive.so
+python_libarchive.egg-info

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ env:
   - DJANGO=1.3
   - DJANGO=1.4
 install:
-  - pip install --timeout=30 -q -e . --use-mirrors
+  - pip install -q .
 script:
   - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ python:
 env:
   - DJANGO=1.3
   - DJANGO=1.4
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq libarchive-dev
 install:
   - pip install .
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,5 @@ install:
   - pip install -q .
 script:
   - make test
+notifications:
+  slack: smartfile:tbDIPzVJIPBpSz29kQw6b8RQ

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: python
+python:
+  - "2.7"
+env:
+  - DJANGO=1.3
+  - DJANGO=1.4
+install:
+  - pip install --timeout=30 -q -e . --use-mirrors
+script:
+  - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
   - DJANGO=1.3
   - DJANGO=1.4
 install:
-  - pip install -q .
+  - pip install .
 script:
   - make test
 notifications:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+test:
+	python tests.py
+
+verify:
+	pyflakes libarchive
+	pep8 --exclude=migrations --ignore=E501,E225 libarchive
+
+install:
+	python setup.py install
+
+publish:
+	python setup.py register
+	python setup.py sdist upload

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,6 @@
+.. image:: https://travis-ci.org/smartfile/python-libarchive.svg
+    :target: https://travis-ci.org/smartfile/python-libarchive
+
 A `SmartFile`_ Open Source project. `Read more`_ about how SmartFile
 uses and contributes to Open Source software.
 

--- a/README.rst
+++ b/README.rst
@@ -7,8 +7,8 @@ uses and contributes to Open Source software.
 .. figure:: http://www.smartfile.com/images/logo.jpg
    :alt: SmartFile
 
-Introduction
------------- 
+Overview
+--------
 A complete wrapper for the libarchive library generated using SWIG.
 Also included in the package are compatibility layers for the Python
 zipfile and tarfile modules.
@@ -26,5 +26,238 @@ For information on using python-libarchive, see `Examples`_
 .. _SmartFile: http://www.smartfile.com/
 .. _Read more: http://www.smartfile.com/open-source.html
 .. _Building: http://code.google.com/p/python-libarchive/wiki/Building
-.. _Examples: http://code.google.com/p/python-libarchive/wiki/Examples
 
+
+Introduction
+------------
+There are actually two APIs exposed by this library.
+
+The first API is a high level pythonic class-based interface that should seem comfortable to Python developers. If you are just getting started with python-libarchive, this is probably where you should start.
+
+The second API is a low-level wrapper around libarchive. This wrapper provides access to the C API exposed by libarchive. A few additions or changes were made to allow easy consumption from Python, but otherwise, most libarchive example code will work (although with Python syntax). This API will be useful to those familiar with libarchive, or those that need functionality not available in the high level API.
+
+Using the high-level API
+------------------------
+The high level API provides a pythonic class-based interface for working with archives. On top of this is a very thin compatibility wrapper for the standard Python zipfile and tarfile modules. Since the standard Python zipfile and tarfile modules both present a different interface, so do the compatibility wrappers.
+
+These compatibility wrappers are provided so that python-libarchive can be a drop-in replacement for the standard modules. A reason to use libarchive instead of the standard modules is that it provides native performance and better memory consumption. So if you already have code using one of these modules, you can sin many cases just replace the standard module with the libarchive alternative.
+
+However, if you are developing a new project, it is recommended that you forgo the compatibility wrappers. Using the high-level API directly means you can support the many archive formats that libarchive does through the same standard interface.
+
+The workhorse of the high-level API is the Archive class. This is a forward-only iterator that allows you to open an archive of any supported formant and iterate it's contents.
+
+   .. code:: python
+
+        import libarchive
+
+        a = libarchive.Archive('my_archive.zip')
+        for entry in a:
+            print entry.pathname
+        a.close()
+
+python-libarchive is also a context manager, so the above could be written as:
+
+   .. code:: python
+        
+        import libarchive
+
+        with libarchive.Archive('my_archive.zip') as a:
+            for entry in a:
+                print entry.pathname
+
+You can also extract files. However, you can only extract the current item. Once you have iterated past an entry, there is no going back.
+
+   .. code:: python
+        
+        import libarchive
+
+        with libarchive.Archive('my_archive.zip') as a:
+            for entry in a:
+                if entry.pathname == 'my_file.txt':
+                    print 'File Contents:', a.read()
+
+Besides the read() method, there is also readpath() and readstream(). Readpath() will extract the file to a path or already opened file. Readstream() will return a file-like object that can be used to read chunks of the file. Larger files being read from the archive should probably use one of these functions instead of read() which will read then entire contents into memory.
+
+Writing archives is also straightforward. You open an Archive() class then add files to it using one of the write() methods.
+
+   .. code:: python
+        
+        import libarchive
+
+        with libarchive.Archive('my_archive.zip', 'w') as a:
+            for name in os.listdir('.'):
+                a.write(libarchive.Entry(name), file(name, 'r').read())
+
+Again, there is also a writepath() method which will write a file-like object or path directly to the archive. The above example could have been written as the following.
+
+   .. code:: python
+        
+        import libarchive
+
+        with libarchive.Archive('my_archive.zip', 'w') as a:
+            for name in os.listdir('.'):
+                a.writepath(libarchive.Entry(name), name)
+
+In addition to the Archive class. There is also SeekableArchive. This class provides random access when reading an archive. It will remember where entries are located within the archive stream, and will close/reopen the stream and seek to the entry's location. So, you can extract an item directly. The first example can be written as follows.
+
+   .. code:: python
+
+        import libarchive
+
+        with libarchive.SeekableArchive('my_archive.zip') as a:
+            print 'File Contents:', a.read('my_file.txt')
+
+There is overhead involved in using the SeekableArchive, so it is suggested that you use the Archive in cases that you don't need random access to an archives entries. In fact, the above example was probably better off using the Archive class.
+
+Using the low-level API
+-----------------------
+Using the low-level API leaves all the work to you. You will need to be careful to create and free libarchive structures yourself. You will also need to be well-versed in the return codes and expected parameters of libarchive. In fact, if you are not, then you probably should stop reading now.
+
+   .. code:: python
+    
+        from libarchive import _libarchive
+
+        a = _libarchive.archive_read_new()
+        _libarchive.archive_read_support_filter_all(a)
+        _libarchive.archive_read_support_format_all(a)
+        _libarchive.archive_read_open_fd(a, f.fileno(), 10240)
+        while True:
+            e = _libarchive.archive_entry_new()
+            try:
+                r = _libarchive.archive_read_next_header2(a, e)
+                if r != _libarchive.ARCHIVE_OK:
+                    break
+                n = _libarchive.archive_entry_pathname(e)
+                if n != 'my_file.txt':
+                    continue
+                l = _libarchive.archive_entry_size(e)
+                s = _libarchive.archive_read_data_into_str(a, l)
+                print 'File Contents:', s
+            finally:
+                _libarchive.archive_entry_free(e)
+        _libarchive.archive_read_close(a)
+        _libarchive.archive_read_free(a)
+
+As you can see this is a lot more work for little benefit. But as stated before, you may end up interacting with the low-level API if some of the functionality you require is not covered in the high-level API.
+
+And as always, patches are appreciated!
+
+
+Installing libarchive
+---------------------
+
+Many Linux distributions include libarchive 2. This extension only works with libarchive 3. In these cases, you must install libarchive to a /usr/local. This will allow it to co-exist with the version installed with your distribution. To install libarchive using autoconf, follow the instructions below.
+
+Prerequisites.
+
+You will need either automake or cmake to install libarchive. Also required is python-dev. In addition, you will also need a compiler and some other tools. To install these prerequisites do the following:
+
+On Debian/Ubuntu:
+
+   ::
+
+        # Install compiler and tools
+        $ sudo apt-get install build-essential libtool python-dev
+
+        # Install automake
+        $ sudo apt-get install automake
+
+        # Or install cmake
+        $ sudo apt-get install cmake
+
+Or CentOS/Fedora:
+
+   ::
+
+        # Install compiler and tools
+        $ sudo yum groupinstall "Development Tools"
+        $ sudo yum install python-devel libtool
+
+        # Install automake
+        $ sudo yum install automake
+
+        # Or install cmake
+        $ sudo yum install cmake
+
+You should now be able to install libarchive.
+
+   ::
+
+        $ wget http://libarchive.googlecode.com/files/libarchive-3.0.3.tar.gz
+        $ tar xzf libarchive-3.0.3.tar.gz
+
+        # Configure using automake...
+        $ cd libarchive-3.0.3/
+        $ build/autogen.sh
+        $ ./configure --prefix=/usr/local
+
+        # Or configure using cmake...
+        $ mkdir build
+        $ cd build
+        $ cmake -DCMAKE_INSTALL_PREFIX=/usr/local ../libarchive-3.0.3
+
+        # Now compile and install...
+        $ make
+        $ sudo make install
+
+Now that the library is installed, you need to tell ld where to find it. The easiest way to do this is to add /usr/local/lib to the ld.so.conf.
+
+   ::
+
+        $ sudo sh -c 'echo /usr/local/lib > /etc/ld.so.conf.d/libarchive3.conf'
+        $ sudo ldconfig
+
+Now libarchive 3.0.3 is installed into /usr/local/. The next step is to build and install python-libarchive.
+
+Installing python-libarchive
+----------------------------
+
+Now that libarchive is installed, you can install the python extension using the steps below.
+
+   ::
+
+        $ wget http://python-libarchive.googlecode.com/files/python-libarchive-3.0.3-2.tar.gz
+        $ tar xzf python-libarchive-3.0.3-2.tar.gz
+        $ cd python-libarchive-3.0.3-2/
+        $ sudo python setup.py install
+
+You can also install using pip.
+
+   ::
+
+        $ pip install python-libarchive
+
+setup.py will explicitly link against version 3.0.3 of the library.
+
+Hacking / Running the Test Suite
+--------------------------------
+
+The test suite is located in the root directory. This is done purposefully to make hacking easier. If you make changes to the library, you can run the test suite against the local copy in the libarchive/ subdirectory rather than the version installed on your system.
+
+However, this means you need to have the extension compiled in this same directory. You will also need SWIG for this step. You can accomplish this using the following commands.
+
+On Debian/Ubuntu:
+
+   ::
+
+        $ sudo apt-get install swig
+
+Or CentOS/Fedora:
+
+   ::
+        
+        $ sudo yum install swig
+
+Now you can re-SWIG the interface and recompile the extension.
+
+   ::
+
+        $ cd libarchive/
+        $ make
+        $ cd ..
+
+Now you can run the test suite from the main directory.
+
+   ::
+        
+        $ python tests.py

--- a/libarchive/__init__.py
+++ b/libarchive/__init__.py
@@ -543,7 +543,7 @@ class Archive(object):
             _libarchive.archive_write_data_from_str(self._a, data)
         _libarchive.archive_write_finish_entry(self._a)
 
-    def writepath(self, f, pathname=None):
+    def writepath(self, f, pathname=None, folder=False):
         '''Writes a file to the archive. f can be a file-like object or a path. Uses
         write() to do the actual writing.'''
         member = self.entry_class.from_file(f, encoding=self.encoding)
@@ -552,6 +552,8 @@ class Archive(object):
                 f = file(f, 'r')
         if pathname:
             member.pathname = pathname
+        if folder and not member.isdir():
+            member.mode = stat.S_IFDIR
         if hasattr(f, 'read'):
             # TODO: optimize this to write directly from f to archive.
             self.write(member, data=f.read())

--- a/libarchive/__init__.py
+++ b/libarchive/__init__.py
@@ -539,6 +539,7 @@ class Archive(object):
         if data:
             member.size = len(data)
         member.to_archive(self)
+        
         if data:
             _libarchive.archive_write_data_from_str(self._a, data)
         _libarchive.archive_write_finish_entry(self._a)
@@ -554,6 +555,7 @@ class Archive(object):
             member.pathname = pathname
         if folder and not member.isdir():
             member.mode = stat.S_IFDIR
+
         if hasattr(f, 'read'):
             # TODO: optimize this to write directly from f to archive.
             self.write(member, data=f.read())

--- a/libarchive/tar.py
+++ b/libarchive/tar.py
@@ -1,32 +1,8 @@
-# Copyright (c) 2011, SmartFile <btimby@smartfile.com>
-# All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-#     * Redistributions of source code must retain the above copyright
-#       notice, this list of conditions and the following disclaimer.
-#     * Redistributions in binary form must reproduce the above copyright
-#       notice, this list of conditions and the following disclaimer in the
-#       documentation and/or other materials provided with the distribution.
-#     * Neither the name of the organization nor the
-#       names of its contributors may be used to endorse or promote products
-#       derived from this software without specific prior written permission.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
-# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-import time
+import os
 from libarchive import is_archive, Entry, SeekableArchive
-from tarfile import DEFAULT_FORMAT, USTAR_FORMAT, GNU_FORMAT, PAX_FORMAT, ENCODING
-from tarfile import REGTYPE, AREGTYPE, LNKTYPE, SYMTYPE, DIRTYPE, FIFOTYPE, CONTTYPE, CHRTYPE, BLKTYPE, GNUTYPE_SPARSE
+from tarfile import DEFAULT_FORMAT, USTAR_FORMAT, GNU_FORMAT, PAX_FORMAT, \
+    ENCODING
+from tarfile import REGTYPE, SYMTYPE, DIRTYPE, FIFOTYPE, CHRTYPE, BLKTYPE
 
 FORMAT_CONVERSION = {
     USTAR_FORMAT:       'tar',
@@ -76,7 +52,13 @@ class TarInfo(Entry):
 
 
 class TarFile(SeekableArchive):
-    def __init__(self, name=None, mode='r', fileobj=None, format=DEFAULT_FORMAT, tarinfo=TarInfo, encoding=ENCODING):
+    getmember   = SeekableArchive.getentry
+    list        = SeekableArchive.printlist
+    extract     = SeekableArchive.readpath
+    extractfile = SeekableArchive.readstream
+
+    def __init__(self, name=None, mode='r', fileobj=None,
+                 format=DEFAULT_FORMAT, tarinfo=TarInfo, encoding=ENCODING):
         if name:
             f = name
         elif fileobj:
@@ -85,12 +67,8 @@ class TarFile(SeekableArchive):
             format = FORMAT_CONVERSION.get(format)
         except KeyError:
             raise Exception('Invalid tar format: %s' % format)
-        super(TarFile, self).__init__(f, mode=mode, format=format, entry_class=tarinfo, encoding=encoding)
-
-    getmember   = SeekableArchive.getentry
-    list        = SeekableArchive.printlist
-    extract     = SeekableArchive.readpath
-    extractfile = SeekableArchive.readstream
+        super(TarFile, self).__init__(f, mode=mode, format=format,
+                                      entry_class=tarinfo, encoding=encoding)
 
     def getmembers(self):
         return list(self)
@@ -99,6 +77,7 @@ class TarFile(SeekableArchive):
         return list(self.iterpaths)
 
     def next(self):
+        raise NotImplementedError
         pass # TODO: how to do this?
 
     def extract(self, member, path=None):
@@ -113,10 +92,10 @@ class TarFile(SeekableArchive):
     def add(self, name, arcname, recursive=True, exclude=None, filter=None):
         pass # TODO: implement this.
 
-    def addfile(tarinfo, fileobj):
+    def addfile(self, tarinfo, fileobj):
         return self.writepath(fileobj, tarinfo)
 
-    def gettarinfo(name=None, arcname=None, fileobj=None):
+    def gettarinfo(self, name=None, arcname=None, fileobj=None):
         if name:
             f = name
         elif fileobj:

--- a/libarchive/zip.py
+++ b/libarchive/zip.py
@@ -1,28 +1,3 @@
-# Copyright (c) 2011, SmartFile <btimby@smartfile.com>
-# All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-#     * Redistributions of source code must retain the above copyright
-#       notice, this list of conditions and the following disclaimer.
-#     * Redistributions in binary form must reproduce the above copyright
-#       notice, this list of conditions and the following disclaimer in the
-#       documentation and/or other materials provided with the distribution.
-#     * Neither the name of the organization nor the
-#       names of its contributors may be used to endorse or promote products
-#       derived from this software without specific prior written permission.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
-# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
 import os, time
 from libarchive import is_archive, Entry, SeekableArchive
 from zipfile import ZIP_STORED, ZIP_DEFLATED
@@ -48,7 +23,7 @@ class ZipEntry(Entry):
         return self.size
 
     def set_file_size(self, value):
-        assert isinstance(size, (int, long)), 'Please provide size as int or long.'
+        assert isinstance(value, (int, long)), 'Please provide size as int or long.'
         self.size = value
 
     file_size = property(get_file_size, set_file_size)

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ except ImportError:
 
 
 name = 'python-libarchive'
-version = '3.1.2'
+version = '3.1.3'
 release = '1'
 versrel = version + '-' + release
 readme = 'README.rst'
@@ -81,7 +81,7 @@ if libarchivePrefix:
                                                 environ.get('LDFLAGS', ''))
 else:
     extra_compile_args = []
-    extra_link_args = ['-l:libarchive.so.13.1.2']
+    extra_link_args = ['-l:libarchive.so.13']
 
 __libarchive = Extension(name='libarchive.__libarchive',
                         sources=['libarchive/_libarchive_wrap.c'],

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,9 @@ class build_ext_extra(build_ext, object):
 libarchivePrefix = environ.get('LIBARCHIVE_PREFIX')
 if libarchivePrefix:
     extra_compile_args = ['-I{0}/include'.format(libarchivePrefix)]
-    extra_link_args = ['-Wl,-rpath={0}/lib'.format(libarchivePrefix)]
+    import platform
+    delim = '=' if platform.system() != 'Darwin' else ','
+    extra_link_args = ['-Wl,-rpath{0}{1}/lib'.format(delim, libarchivePrefix)]
     environ['LDFLAGS'] = '-L{0}/lib {1}'.format(libarchivePrefix,
                                                 environ.get('LDFLAGS', ''))
 else:
@@ -117,3 +119,4 @@ setup(name = name,
       },
       ext_modules = [__libarchive],
       )
+

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (c) 2011, SmartFile <btimby@smartfile.com>
+# Copyright (c) 2015, SmartFile <tcunningham@smartfile.com>
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -36,7 +36,7 @@ except ImportError:
 
 
 name = 'python-libarchive'
-version = '3.1.3'
+version = '3.1.4'
 release = '1'
 versrel = version + '-' + release
 readme = 'README.rst'
@@ -98,9 +98,9 @@ setup(name = name,
       long_description = long_description,
       license = 'BSD-style license',
       platforms = ['any'],
-      author = 'Ben Timby',
-      author_email = 'btimby at gmail dot com',
-      url = 'http://code.google.com/p/python-libarchive/',
+      author = 'Ben Timby, Travis Cunningham, Ryan Johnston, SmartFile',
+      author_email = 'tcunningham@smartfile.com',
+      url = 'https://github.com/smartfile/python-libarchive',
       download_url = download_url,
       packages = ['libarchive'],
       classifiers = [

--- a/tests.py
+++ b/tests.py
@@ -175,12 +175,13 @@ class TestZipWrite(unittest.TestCase):
 
         f = file(ZIPPATH, mode='w')
         z = ZipFile(f, 'w')
-        z.writepath(None, '/testdir', folder=True)
+        z.writepath('/home/user/testpath', pathname='/testdir', folder=True)
         z.close()
         f.close()
 
         f = file(ZIPPATH, mode='r')
         z = ZipFile(f, 'r')
+
         assert len(z.entries) == 1
         assert z.entries[0].isdir()
         z.close()

--- a/tests.py
+++ b/tests.py
@@ -170,6 +170,22 @@ class TestZipWrite(unittest.TestCase):
             z.writepath(file(os.path.join(TMPDIR, fname), 'r'))
         z.close()
 
+    def test_writepath_directory(self):
+        """ Test writing a directory. """
+
+        f = file(ZIPPATH, mode='w')
+        z = ZipFile(f, 'w')
+        z.writepath(None, '/testdir', folder=True)
+        z.close()
+        f.close()
+
+        f = file(ZIPPATH, mode='r')
+        z = ZipFile(f, 'r')
+        assert len(z.entries) == 1
+        assert z.entries[0].isdir()
+        z.close()
+        f.close()
+
     def test_writestream(self):
         f = file(ZIPPATH, mode='w')
         z = ZipFile(f, 'w')

--- a/tests.py
+++ b/tests.py
@@ -43,11 +43,12 @@ FILENAMES = [
     #'álért.txt',
 ]
 
+
 def make_temp_files():
-    print TMPDIR
     if not os.path.exists(ZIPPATH):
         for name in FILENAMES:
             file(os.path.join(TMPDIR, name), 'w').write(''.join(random.sample(string.printable, 10)))
+
 
 def make_temp_archive():
     if not os.access(ZIPCMD, os.X_OK):
@@ -56,7 +57,7 @@ def make_temp_archive():
     make_temp_files()
     cmd.extend(FILENAMES)
     os.chdir(TMPDIR)
-    subprocess.call(cmd)
+    subprocess.call(cmd, stdout=subprocess.PIPE)
 
 
 class TestIsArchiveName(unittest.TestCase):
@@ -175,15 +176,18 @@ class TestZipWrite(unittest.TestCase):
 
         f = file(ZIPPATH, mode='w')
         z = ZipFile(f, 'w')
-        z.writepath('/home/user/testpath', pathname='/testdir', folder=True)
+        z.writepath(None, pathname='/testdir', folder=True)
+        z.writepath(None, pathname='/testdir/testinside', folder=True)
         z.close()
         f.close()
 
         f = file(ZIPPATH, mode='r')
         z = ZipFile(f, 'r')
 
-        assert len(z.entries) == 1
-        assert z.entries[0].isdir()
+        entries = z.infolist()
+
+        assert len(entries) == 2
+        assert entries[0].isdir()
         z.close()
         f.close()
 


### PR DESCRIPTION
clang requires ',' rather than '=' for paths in rpath.