### PR TITLE
readpath: fix getting basedir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ venv
 
 build
 libarchive/__libarchive.so
+libarchive/_libarchive_wrap.o
 python_libarchive.egg-info

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 venv
 *.pyc
 *.swp
+
+build
+libarchive/__libarchive.so
+python_libarchive.egg-info

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ env:
   - DJANGO=1.3
   - DJANGO=1.4
 install:
-  - pip install --timeout=30 -q -e . --use-mirrors
+  - pip install -q .
 script:
   - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ jobs:
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq libarchive-dev
-  - pyenv shell $TRAVIS_PYTHON_VERSION
+  - pyenv shell $(python -c 'import platform; print(platform.python_version())')
 install:
   - make build
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ jobs:
     - python: "2.7"
       env: PYVER=2.7
     - python: "3.6"
-      env: PYVER=3.6.7
+      env: PYVER=3.6
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq libarchive-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,15 @@
 language: python
-python:
-  - "2.7"
-env:
-  - DJANGO=1.3
-  - DJANGO=1.4
+jobs:
+  include:
+    - python: "2.7"
+      env: PYVER=2.7
+    - python: "3.6"
+      env: PYVER=3.6
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq libarchive-dev
 install:
-  - pip install .
+  - make build
 script:
   - make test
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ jobs:
     - python: "2.7"
       env: PYVER=2.7
     - python: "3.6"
-      env: PYVER=3.6
+      env: PYVER=3.6.7
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq libarchive-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ python:
 env:
   - DJANGO=1.3
   - DJANGO=1.4
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq libarchive-dev
 install:
   - pip install .
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ jobs:
       env: PYVER=3.6
 before_install:
   - sudo apt-get update -qq
-  - sudo apt-get install -qq libarchive-dev python3-dev
+  - sudo apt-get install -qq libarchive-dev
 install:
   - make build
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,5 @@ install:
   - pip install -q .
 script:
   - make test
+notifications:
+  slack: smartfile:tbDIPzVJIPBpSz29kQw6b8RQ

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: python
+python:
+  - "2.7"
+env:
+  - DJANGO=1.3
+  - DJANGO=1.4
+install:
+  - pip install --timeout=30 -q -e . --use-mirrors
+script:
+  - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ jobs:
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq libarchive-dev
-  - pyenv shell $PYTHON
+  - pyenv shell $TRAVIS_PYTHON_VERSION
 install:
   - make build
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
   - DJANGO=1.3
   - DJANGO=1.4
 install:
-  - pip install -q .
+  - pip install .
 script:
   - make test
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ jobs:
       env: PYVER=3.6
 before_install:
   - sudo apt-get update -qq
-  - sudo apt-get install -qq libarchive-dev
+  - sudo apt-get install -qq libarchive-dev python3-dev
 install:
   - make build
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ jobs:
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq libarchive-dev
+  - pyenv shell $PYTHON
 install:
   - make build
 script:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+test:
+	python tests.py
+
+verify:
+	pyflakes libarchive
+	pep8 --exclude=migrations --ignore=E501,E225 libarchive
+
+install:
+	python setup.py install
+
+publish:
+	python setup.py register
+	python setup.py sdist upload

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+build:
+	make -C libarchive
+
 test:
 	python tests.py
 
@@ -11,3 +14,6 @@ install:
 publish:
 	python setup.py register
 	python setup.py sdist upload
+
+clean:
+	make -C libarchive clean

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,6 @@
+.. image:: https://travis-ci.org/smartfile/python-libarchive.svg
+    :target: https://travis-ci.org/smartfile/python-libarchive
+
 A `SmartFile`_ Open Source project. `Read more`_ about how SmartFile
 uses and contributes to Open Source software.
 

--- a/README.rst
+++ b/README.rst
@@ -21,8 +21,6 @@ Libarchive supports the following:
 
 For information on installing libarchive and python-libarchive, see the `Building`_.
 
-For information on using python-libarchive, see `Examples`_
-
 .. _SmartFile: http://www.smartfile.com/
 .. _Read more: http://www.smartfile.com/open-source.html
 .. _Building: http://code.google.com/p/python-libarchive/wiki/Building

--- a/README.rst
+++ b/README.rst
@@ -7,8 +7,8 @@ uses and contributes to Open Source software.
 .. figure:: http://www.smartfile.com/images/logo.jpg
    :alt: SmartFile
 
-Introduction
------------- 
+Overview
+--------
 A complete wrapper for the libarchive library generated using SWIG.
 Also included in the package are compatibility layers for the Python
 zipfile and tarfile modules.
@@ -26,5 +26,238 @@ For information on using python-libarchive, see `Examples`_
 .. _SmartFile: http://www.smartfile.com/
 .. _Read more: http://www.smartfile.com/open-source.html
 .. _Building: http://code.google.com/p/python-libarchive/wiki/Building
-.. _Examples: http://code.google.com/p/python-libarchive/wiki/Examples
 
+
+Introduction
+------------
+There are actually two APIs exposed by this library.
+
+The first API is a high level pythonic class-based interface that should seem comfortable to Python developers. If you are just getting started with python-libarchive, this is probably where you should start.
+
+The second API is a low-level wrapper around libarchive. This wrapper provides access to the C API exposed by libarchive. A few additions or changes were made to allow easy consumption from Python, but otherwise, most libarchive example code will work (although with Python syntax). This API will be useful to those familiar with libarchive, or those that need functionality not available in the high level API.
+
+Using the high-level API
+------------------------
+The high level API provides a pythonic class-based interface for working with archives. On top of this is a very thin compatibility wrapper for the standard Python zipfile and tarfile modules. Since the standard Python zipfile and tarfile modules both present a different interface, so do the compatibility wrappers.
+
+These compatibility wrappers are provided so that python-libarchive can be a drop-in replacement for the standard modules. A reason to use libarchive instead of the standard modules is that it provides native performance and better memory consumption. So if you already have code using one of these modules, you can sin many cases just replace the standard module with the libarchive alternative.
+
+However, if you are developing a new project, it is recommended that you forgo the compatibility wrappers. Using the high-level API directly means you can support the many archive formats that libarchive does through the same standard interface.
+
+The workhorse of the high-level API is the Archive class. This is a forward-only iterator that allows you to open an archive of any supported formant and iterate it's contents.
+
+   .. code:: python
+
+        import libarchive
+
+        a = libarchive.Archive('my_archive.zip')
+        for entry in a:
+            print entry.pathname
+        a.close()
+
+python-libarchive is also a context manager, so the above could be written as:
+
+   .. code:: python
+        
+        import libarchive
+
+        with libarchive.Archive('my_archive.zip') as a:
+            for entry in a:
+                print entry.pathname
+
+You can also extract files. However, you can only extract the current item. Once you have iterated past an entry, there is no going back.
+
+   .. code:: python
+        
+        import libarchive
+
+        with libarchive.Archive('my_archive.zip') as a:
+            for entry in a:
+                if entry.pathname == 'my_file.txt':
+                    print 'File Contents:', a.read()
+
+Besides the read() method, there is also readpath() and readstream(). Readpath() will extract the file to a path or already opened file. Readstream() will return a file-like object that can be used to read chunks of the file. Larger files being read from the archive should probably use one of these functions instead of read() which will read then entire contents into memory.
+
+Writing archives is also straightforward. You open an Archive() class then add files to it using one of the write() methods.
+
+   .. code:: python
+        
+        import libarchive
+
+        with libarchive.Archive('my_archive.zip', 'w') as a:
+            for name in os.listdir('.'):
+                a.write(libarchive.Entry(name), file(name, 'r').read())
+
+Again, there is also a writepath() method which will write a file-like object or path directly to the archive. The above example could have been written as the following.
+
+   .. code:: python
+        
+        import libarchive
+
+        with libarchive.Archive('my_archive.zip', 'w') as a:
+            for name in os.listdir('.'):
+                a.writepath(libarchive.Entry(name), name)
+
+In addition to the Archive class. There is also SeekableArchive. This class provides random access when reading an archive. It will remember where entries are located within the archive stream, and will close/reopen the stream and seek to the entry's location. So, you can extract an item directly. The first example can be written as follows.
+
+   .. code:: python
+
+        import libarchive
+
+        with libarchive.SeekableArchive('my_archive.zip') as a:
+            print 'File Contents:', a.read('my_file.txt')
+
+There is overhead involved in using the SeekableArchive, so it is suggested that you use the Archive in cases that you don't need random access to an archives entries. In fact, the above example was probably better off using the Archive class.
+
+Using the low-level API
+-----------------------
+Using the low-level API leaves all the work to you. You will need to be careful to create and free libarchive structures yourself. You will also need to be well-versed in the return codes and expected parameters of libarchive. In fact, if you are not, then you probably should stop reading now.
+
+   .. code:: python
+    
+        from libarchive import _libarchive
+
+        a = _libarchive.archive_read_new()
+        _libarchive.archive_read_support_filter_all(a)
+        _libarchive.archive_read_support_format_all(a)
+        _libarchive.archive_read_open_fd(a, f.fileno(), 10240)
+        while True:
+            e = _libarchive.archive_entry_new()
+            try:
+                r = _libarchive.archive_read_next_header2(a, e)
+                if r != _libarchive.ARCHIVE_OK:
+                    break
+                n = _libarchive.archive_entry_pathname(e)
+                if n != 'my_file.txt':
+                    continue
+                l = _libarchive.archive_entry_size(e)
+                s = _libarchive.archive_read_data_into_str(a, l)
+                print 'File Contents:', s
+            finally:
+                _libarchive.archive_entry_free(e)
+        _libarchive.archive_read_close(a)
+        _libarchive.archive_read_free(a)
+
+As you can see this is a lot more work for little benefit. But as stated before, you may end up interacting with the low-level API if some of the functionality you require is not covered in the high-level API.
+
+And as always, patches are appreciated!
+
+
+Installing libarchive
+---------------------
+
+Many Linux distributions include libarchive 2. This extension only works with libarchive 3. In these cases, you must install libarchive to a /usr/local. This will allow it to co-exist with the version installed with your distribution. To install libarchive using autoconf, follow the instructions below.
+
+Prerequisites.
+
+You will need either automake or cmake to install libarchive. Also required is python-dev. In addition, you will also need a compiler and some other tools. To install these prerequisites do the following:
+
+On Debian/Ubuntu:
+
+   ::
+
+        # Install compiler and tools
+        $ sudo apt-get install build-essential libtool python-dev
+
+        # Install automake
+        $ sudo apt-get install automake
+
+        # Or install cmake
+        $ sudo apt-get install cmake
+
+Or CentOS/Fedora:
+
+   ::
+
+        # Install compiler and tools
+        $ sudo yum groupinstall "Development Tools"
+        $ sudo yum install python-devel libtool
+
+        # Install automake
+        $ sudo yum install automake
+
+        # Or install cmake
+        $ sudo yum install cmake
+
+You should now be able to install libarchive.
+
+   ::
+
+        $ wget http://libarchive.googlecode.com/files/libarchive-3.0.3.tar.gz
+        $ tar xzf libarchive-3.0.3.tar.gz
+
+        # Configure using automake...
+        $ cd libarchive-3.0.3/
+        $ build/autogen.sh
+        $ ./configure --prefix=/usr/local
+
+        # Or configure using cmake...
+        $ mkdir build
+        $ cd build
+        $ cmake -DCMAKE_INSTALL_PREFIX=/usr/local ../libarchive-3.0.3
+
+        # Now compile and install...
+        $ make
+        $ sudo make install
+
+Now that the library is installed, you need to tell ld where to find it. The easiest way to do this is to add /usr/local/lib to the ld.so.conf.
+
+   ::
+
+        $ sudo sh -c 'echo /usr/local/lib > /etc/ld.so.conf.d/libarchive3.conf'
+        $ sudo ldconfig
+
+Now libarchive 3.0.3 is installed into /usr/local/. The next step is to build and install python-libarchive.
+
+Installing python-libarchive
+----------------------------
+
+Now that libarchive is installed, you can install the python extension using the steps below.
+
+   ::
+
+        $ wget http://python-libarchive.googlecode.com/files/python-libarchive-3.0.3-2.tar.gz
+        $ tar xzf python-libarchive-3.0.3-2.tar.gz
+        $ cd python-libarchive-3.0.3-2/
+        $ sudo python setup.py install
+
+You can also install using pip.
+
+   ::
+
+        $ pip install python-libarchive
+
+setup.py will explicitly link against version 3.0.3 of the library.
+
+Hacking / Running the Test Suite
+--------------------------------
+
+The test suite is located in the root directory. This is done purposefully to make hacking easier. If you make changes to the library, you can run the test suite against the local copy in the libarchive/ subdirectory rather than the version installed on your system.
+
+However, this means you need to have the extension compiled in this same directory. You will also need SWIG for this step. You can accomplish this using the following commands.
+
+On Debian/Ubuntu:
+
+   ::
+
+        $ sudo apt-get install swig
+
+Or CentOS/Fedora:
+
+   ::
+        
+        $ sudo yum install swig
+
+Now you can re-SWIG the interface and recompile the extension.
+
+   ::
+
+        $ cd libarchive/
+        $ make
+        $ cd ..
+
+Now you can run the test suite from the main directory.
+
+   ::
+        
+        $ python tests.py

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,8 +40,8 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'python-libarchive'
-copyright = u'2012, Ben Timby'
+project = 'python-libarchive'
+copyright = '2012, Ben Timby'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -178,8 +178,8 @@ htmlhelp_basename = 'python-libarchivedoc'
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('index', 'python-libarchive.tex', u'python-libarchive Documentation',
-   u'Ben Timby', 'manual'),
+  ('index', 'python-libarchive.tex', 'python-libarchive Documentation',
+   'Ben Timby', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -211,6 +211,6 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'python-libarchive', u'python-libarchive Documentation',
-     [u'Ben Timby'], 1)
+    ('index', 'python-libarchive', 'python-libarchive Documentation',
+     ['Ben Timby'], 1)
 ]

--- a/libarchive/Makefile
+++ b/libarchive/Makefile
@@ -1,12 +1,8 @@
 CFLAGS     = -g
 INCLUDE    = -I/usr/include -I.
-LIBS       = -L/usr/local/lib -l:libarchive.so.13.1.2
+LIBS       = -larchive
 
-#if PYTHON_VERSION
-PYVER = $(PYTHON_VERSION)
-#else
-PYVER = 2.7
-#endif
+PYVER ?= 2.7
 
 all: __libarchive.so
 

--- a/libarchive/__init__.py
+++ b/libarchive/__init__.py
@@ -154,7 +154,7 @@ def is_archive(f, formats=(None, ), filters=(None, )):
     This function will return True if the file can be opened as an archive using the given
     format(s)/filter(s).'''
     if isinstance(f, str):
-        f = file(f, 'r')
+        f = open(f, 'r')
     a = _libarchive.archive_read_new()
     for format in formats:
         format = get_func(format, FORMATS, 0)
@@ -392,7 +392,7 @@ class Archive(object):
         self.blocksize = blocksize
         if isinstance(f, str):
             self.filename = f
-            f = file(f, mode)
+            f = open(f, mode)
             # Only close it if we opened it...
             self._defer_close = True
         elif hasattr(f, 'fileno'):
@@ -524,7 +524,7 @@ class Archive(object):
             basedir = os.path.basename(f)
             if not os.path.exists(basedir):
                 os.makedirs(basedir)
-            f = file(f, 'w')
+            f = open(f, 'w')
         return _libarchive.archive_read_data_into_fd(self._a, f.fileno())
 
     def readstream(self, size):
@@ -550,7 +550,7 @@ class Archive(object):
         member = self.entry_class.from_file(f, encoding=self.encoding)
         if isinstance(f, str):
             if os.path.isfile(f):
-                f = file(f, 'r')
+                f = open(f, 'r')
         if pathname:
             member.pathname = pathname
         if folder and not member.isdir():
@@ -588,7 +588,7 @@ class SeekableArchive(Archive):
         # Convert file to open file. We need this to reopen the archive.
         mode = kwargs.setdefault('mode', 'r')
         if isinstance(f, str):
-            f = file(f, mode)
+            f = open(f, mode)
         super(SeekableArchive, self).__init__(f, **kwargs)
         self.entries = []
         self.eof = False

--- a/libarchive/__init__.py
+++ b/libarchive/__init__.py
@@ -312,10 +312,11 @@ class Entry(object):
             call_and_check(_libarchive.archive_read_next_header2, archive._a, archive._a, e)
             mode = _libarchive.archive_entry_filetype(e)
             mode |= _libarchive.archive_entry_perm(e)
+
             if PY3:
-                pathname=_libarchive.archive_entry_pathname(e)
+                pathname = _libarchive.archive_entry_pathname(e)
             else:
-                pathname=_libarchive.archive_entry_pathname(e).decode(encoding),
+                pathname = _libarchive.archive_entry_pathname(e).decode(encoding)
 
             entry = cls(
                 pathname=pathname,
@@ -628,11 +629,7 @@ class SeekableArchive(Archive):
     def getentry(self, pathname):
         '''Take a name or entry object and returns an entry object.'''
         for entry in self:
-            if PY3:
-                entry_pathname = entry.pathname
-            if not PY3:
-                entry_pathname = entry.pathname[0]
-            if entry_pathname == pathname:
+            if entry.pathname == pathname:
                 return entry
         raise KeyError(pathname)
 

--- a/libarchive/__init__.py
+++ b/libarchive/__init__.py
@@ -521,7 +521,7 @@ class Archive(object):
         '''Write current archive entry contents to file. f can be a file-like object or
         a path.'''
         if isinstance(f, basestring):
-            basedir = os.path.basename(f)
+            basedir = os.path.dirname(f)
             if not os.path.exists(basedir):
                 os.makedirs(basedir)
             f = file(f, 'w')

--- a/libarchive/__init__.py
+++ b/libarchive/__init__.py
@@ -31,9 +31,9 @@ import warnings
 
 from libarchive import _libarchive
 try:
-    from cStringIO import StringIO
+    from io import StringIO
 except ImportError:
-    from StringIO import StringIO
+    from io import StringIO
 
 # Suggested block size for libarchive. Libarchive may adjust it.
 BLOCK_SIZE = 10240
@@ -134,7 +134,7 @@ def is_archive_name(filename, formats=None):
     This function will return the name of the most likely archive format, None if the file is
     unlikely to be an archive.'''
     if formats is None:
-        formats = FORMAT_EXTENSIONS.values()
+        formats = list(FORMAT_EXTENSIONS.values())
     format, filter = guess_format(filename)
     if format in formats:
         return format
@@ -153,7 +153,7 @@ def is_archive(f, formats=(None, ), filters=(None, )):
 
     This function will return True if the file can be opened as an archive using the given
     format(s)/filter(s).'''
-    if isinstance(f, basestring):
+    if isinstance(f, str):
         f = file(f, 'r')
     a = _libarchive.archive_read_new()
     for format in formats:
@@ -165,7 +165,7 @@ def is_archive(f, formats=(None, ), filters=(None, )):
         filter = get_func(filter, FILTERS, 0)
         if filter is None:
             return False
-        filter(a)
+        list(filter(a))
     try:
         try:
             call_and_check(_libarchive.archive_read_open_fd, a, a, f.fileno(), BLOCK_SIZE)
@@ -330,7 +330,7 @@ class Entry(object):
         if entry is None:
             entry = cls(encoding=encoding)
         if entry.pathname is None:
-            if isinstance(f, basestring):
+            if isinstance(f, str):
                 st = os.stat(f)
                 entry.pathname = f
                 entry.size = st.st_size
@@ -390,7 +390,7 @@ class Archive(object):
         self._stream = None
         self.encoding = encoding
         self.blocksize = blocksize
-        if isinstance(f, basestring):
+        if isinstance(f, str):
             self.filename = f
             f = file(f, mode)
             # Only close it if we opened it...
@@ -520,7 +520,7 @@ class Archive(object):
     def readpath(self, f):
         '''Write current archive entry contents to file. f can be a file-like object or
         a path.'''
-        if isinstance(f, basestring):
+        if isinstance(f, str):
             basedir = os.path.basename(f)
             if not os.path.exists(basedir):
                 os.makedirs(basedir)
@@ -534,7 +534,7 @@ class Archive(object):
 
     def write(self, member, data=None):
         '''Writes a string buffer to the archive as the given entry.'''
-        if isinstance(member, basestring):
+        if isinstance(member, str):
             member = self.entry_class(pathname=member, encoding=self.encoding)
         if data:
             member.size = len(data)
@@ -548,7 +548,7 @@ class Archive(object):
         '''Writes a file to the archive. f can be a file-like object or a path. Uses
         write() to do the actual writing.'''
         member = self.entry_class.from_file(f, encoding=self.encoding)
-        if isinstance(f, basestring):
+        if isinstance(f, str):
             if os.path.isfile(f):
                 f = file(f, 'r')
         if pathname:
@@ -587,7 +587,7 @@ class SeekableArchive(Archive):
         self._stream = None
         # Convert file to open file. We need this to reopen the archive.
         mode = kwargs.setdefault('mode', 'r')
-        if isinstance(f, basestring):
+        if isinstance(f, str):
             f = file(f, mode)
         super(SeekableArchive, self).__init__(f, **kwargs)
         self.entries = []

--- a/libarchive/__init__.py
+++ b/libarchive/__init__.py
@@ -30,10 +30,9 @@ import time
 import warnings
 
 from libarchive import _libarchive
-try:
-    from io import StringIO
-except ImportError:
-    from io import StringIO
+from io import StringIO
+
+PY3 = sys.version_info[0] == 3
 
 # Suggested block size for libarchive. Libarchive may adjust it.
 BLOCK_SIZE = 10240
@@ -165,7 +164,7 @@ def is_archive(f, formats=(None, ), filters=(None, )):
         filter = get_func(filter, FILTERS, 0)
         if filter is None:
             return False
-        list(filter(a))
+        filter(a)
     try:
         try:
             call_and_check(_libarchive.archive_read_open_fd, a, a, f.fileno(), BLOCK_SIZE)
@@ -175,6 +174,7 @@ def is_archive(f, formats=(None, ), filters=(None, )):
     finally:
         _libarchive.archive_read_close(a)
         _libarchive.archive_read_free(a)
+        f.close()
 
 
 class EntryReadStream(object):
@@ -271,7 +271,7 @@ class EntryWriteStream(object):
         if self.buffer:
             self.buffer.write(data)
         else:
-            _libarchive.archive_write_data_from_str(self.archive._a, data)
+            _libarchive.archive_write_data_from_str(self.archive._a, data.encode('utf-8'))
         self.bytes += len(data)
 
     def close(self):
@@ -280,7 +280,7 @@ class EntryWriteStream(object):
         if self.buffer:
             self.entry.size = self.buffer.tell()
             self.entry.to_archive(self.archive)
-            _libarchive.archive_write_data_from_str(self.archive._a, self.buffer.getvalue())
+            _libarchive.archive_write_data_from_str(self.archive._a, self.buffer.getvalue().encode('utf-8'))
         _libarchive.archive_write_finish_entry(self.archive._a)
 
         # Call archive.close() with _defer True to let it know we have been
@@ -312,8 +312,13 @@ class Entry(object):
             call_and_check(_libarchive.archive_read_next_header2, archive._a, archive._a, e)
             mode = _libarchive.archive_entry_filetype(e)
             mode |= _libarchive.archive_entry_perm(e)
-            entry = cls(
+            if PY3:
+                pathname=_libarchive.archive_entry_pathname(e)
+            else:
                 pathname=_libarchive.archive_entry_pathname(e).decode(encoding),
+
+            entry = cls(
+                pathname=pathname,
                 size=_libarchive.archive_entry_size(e),
                 mtime=_libarchive.archive_entry_mtime(e),
                 mode=mode,
@@ -353,7 +358,10 @@ class Entry(object):
         '''Creates an archive header and writes it to the given archive.'''
         e = _libarchive.archive_entry_new()
         try:
-            _libarchive.archive_entry_set_pathname(e, self.pathname.encode(self.encoding))
+            if PY3:
+                _libarchive.archive_entry_set_pathname(e, self.pathname)
+            else:
+                _libarchive.archive_entry_set_pathname(e, self.pathname.encode(self.encoding))
             _libarchive.archive_entry_set_filetype(e, stat.S_IFMT(self.mode))
             _libarchive.archive_entry_set_perm(e, stat.S_IMODE(self.mode))
             _libarchive.archive_entry_set_size(e, self.size)
@@ -539,9 +547,12 @@ class Archive(object):
         if data:
             member.size = len(data)
         member.to_archive(self)
-        
+
         if data:
-            _libarchive.archive_write_data_from_str(self._a, data)
+            if PY3:
+                result = _libarchive.archive_write_data_from_str(self._a, data.encode('utf8'))
+            else:
+                result = _libarchive.archive_write_data_from_str(self._a, data)
         _libarchive.archive_write_finish_entry(self._a)
 
     def writepath(self, f, pathname=None, folder=False):
@@ -614,7 +625,11 @@ class SeekableArchive(Archive):
     def getentry(self, pathname):
         '''Take a name or entry object and returns an entry object.'''
         for entry in self:
-            if entry.pathname == pathname:
+            if PY3:
+                entry_pathname = entry.pathname
+            if not PY3:
+                entry_pathname = entry.pathname[0]
+            if entry_pathname == pathname:
                 return entry
         raise KeyError(pathname)
 

--- a/libarchive/__init__.py
+++ b/libarchive/__init__.py
@@ -117,7 +117,10 @@ def get_func(name, items, index):
 
 
 def guess_format(filename):
-    filename, ext = os.path.splitext(filename)
+    if isinstance(filename, int):
+        filename = ext = ''
+    else:
+        filename, ext = os.path.splitext(filename)
     filter = FILTER_EXTENSIONS.get(ext)
     if filter:
         filename, ext = os.path.splitext(filename)

--- a/libarchive/__init__.py
+++ b/libarchive/__init__.py
@@ -550,7 +550,10 @@ class Archive(object):
 
         if data:
             if PY3:
-                result = _libarchive.archive_write_data_from_str(self._a, data.encode('utf8'))
+                if isinstance(data, bytes):
+                    result = _libarchive.archive_write_data_from_str(self._a, data)
+                else:
+                    result = _libarchive.archive_write_data_from_str(self._a, data.encode('utf8'))
             else:
                 result = _libarchive.archive_write_data_from_str(self._a, data)
         _libarchive.archive_write_finish_entry(self._a)

--- a/libarchive/__init__.py
+++ b/libarchive/__init__.py
@@ -543,7 +543,7 @@ class Archive(object):
             _libarchive.archive_write_data_from_str(self._a, data)
         _libarchive.archive_write_finish_entry(self._a)
 
-    def writepath(self, f, pathname=None):
+    def writepath(self, f, pathname=None, folder=False):
         '''Writes a file to the archive. f can be a file-like object or a path. Uses
         write() to do the actual writing.'''
         member = self.entry_class.from_file(f, encoding=self.encoding)
@@ -552,6 +552,8 @@ class Archive(object):
                 f = file(f, 'r')
         if pathname:
             member.pathname = pathname
+        if folder and not member.isdir():
+            member.mode = stat.S_IFDIR
         if hasattr(f, 'read'):
             # TODO: optimize this to write directly from f to archive.
             self.write(member, data=f.read())

--- a/libarchive/__init__.py
+++ b/libarchive/__init__.py
@@ -539,6 +539,7 @@ class Archive(object):
         if data:
             member.size = len(data)
         member.to_archive(self)
+        
         if data:
             _libarchive.archive_write_data_from_str(self._a, data)
         _libarchive.archive_write_finish_entry(self._a)
@@ -554,6 +555,7 @@ class Archive(object):
             member.pathname = pathname
         if folder and not member.isdir():
             member.mode = stat.S_IFDIR
+
         if hasattr(f, 'read'):
             # TODO: optimize this to write directly from f to archive.
             self.write(member, data=f.read())

--- a/libarchive/_libarchive.i
+++ b/libarchive/_libarchive.i
@@ -360,7 +360,7 @@ extern const char	*archive_error_string(struct archive *);
 %inline %{
 PyObject *archive_read_data_into_str(struct archive *archive, int len) {
     PyObject *str = NULL;
-    if (!(str = PyString_FromStringAndSize(NULL, len))) {
+    if (!(str = PyUnicode_FromStringAndSize(NULL, len))) {
         PyErr_SetString(PyExc_MemoryError, "could not allocate string.");
         return NULL;
     }

--- a/libarchive/_libarchive_wrap.c
+++ b/libarchive/_libarchive_wrap.c
@@ -3274,11 +3274,7 @@ SWIG_FromCharPtrAndSize(const char* carray, size_t size)
       return pchar_descriptor ? 
 	SWIG_InternalNewPointerObj((char *)(carray), pchar_descriptor, 0) : SWIG_Py_Void();
     } else {
-#if PY_VERSION_HEX >= 0x03000000
-      return PyUnicode_FromStringAndSize(carray, (int)(size));
-#else
-      return PyString_FromStringAndSize(carray, (int)(size));
-#endif
+return PyUnicode_FromStringAndSize(carray, (int)(size));
     }
   } else {
     return SWIG_Py_Void();
@@ -3342,7 +3338,7 @@ SWIG_AsVal_unsigned_SS_short (PyObject * obj, unsigned short *val)
 
 PyObject *archive_read_data_into_str(struct archive *archive, int len) {
     PyObject *str = NULL;
-    if (!(str = PyString_FromStringAndSize(NULL, len))) {
+    if (!(str = PyUnicode_FromStringAndSize(NULL, len))) {
         PyErr_SetString(PyExc_MemoryError, "could not allocate string.");
         return NULL;
     }

--- a/libarchive/_libarchive_wrap.c
+++ b/libarchive/_libarchive_wrap.c
@@ -739,7 +739,7 @@ SWIG_UnpackDataName(const char *c, void *ptr, size_t sz, const char *name) {
 #define PyString_Size(str) PyBytes_Size(str)	
 #define PyString_InternFromString(key) PyUnicode_InternFromString(key)
 #define Py_TPFLAGS_HAVE_CLASS Py_TPFLAGS_BASETYPE
-#define PyString_AS_STRING(x) PyUnicode_AS_STRING(x)
+#define PyString_AS_STRING(x) PyUnicode_AS_UNICODE(x)
 #define _PyLong_FromSsize_t(x) PyLong_FromSsize_t(x)
 
 #endif

--- a/libarchive/_libarchive_wrap.c
+++ b/libarchive/_libarchive_wrap.c
@@ -739,7 +739,7 @@ SWIG_UnpackDataName(const char *c, void *ptr, size_t sz, const char *name) {
 #define PyString_Size(str) PyBytes_Size(str)	
 #define PyString_InternFromString(key) PyUnicode_InternFromString(key)
 #define Py_TPFLAGS_HAVE_CLASS Py_TPFLAGS_BASETYPE
-#define PyString_AS_STRING(x) PyUnicode_AS_UNICODE(x)
+#define PyString_AS_STRING(x) PyBytes_AsString(x)
 #define _PyLong_FromSsize_t(x) PyLong_FromSsize_t(x)
 
 #endif
@@ -3274,7 +3274,11 @@ SWIG_FromCharPtrAndSize(const char* carray, size_t size)
       return pchar_descriptor ? 
 	SWIG_InternalNewPointerObj((char *)(carray), pchar_descriptor, 0) : SWIG_Py_Void();
     } else {
-return PyUnicode_FromStringAndSize(carray, (int)(size));
+#if PY_VERSION_HEX >= 0x03000000
+      return PyUnicode_FromStringAndSize(carray, (int)(size));
+#else
+      return PyString_FromStringAndSize(carray, (int)(size));
+#endif
     }
   } else {
     return SWIG_Py_Void();
@@ -3338,10 +3342,17 @@ SWIG_AsVal_unsigned_SS_short (PyObject * obj, unsigned short *val)
 
 PyObject *archive_read_data_into_str(struct archive *archive, int len) {
     PyObject *str = NULL;
-    if (!(str = PyUnicode_FromStringAndSize(NULL, len))) {
+#if PY_VERSION_HEX >= 0x03000000
+    if (!(str = PyBytes_FromStringAndSize(NULL, len))) {
         PyErr_SetString(PyExc_MemoryError, "could not allocate string.");
         return NULL;
     }
+#else
+    if (!(str = PyString_FromStringAndSize(NULL, len))) {
+	    PyErr_SetString(PyExc_MemoryError, "could not allocate string.");
+	    return NULL;
+    }
+#endif
     if (len != archive_read_data(archive, PyString_AS_STRING(str), len)) {
         PyErr_SetString(PyExc_RuntimeError, "could not read requested data.");
         return NULL;

--- a/libarchive/tar.py
+++ b/libarchive/tar.py
@@ -1,32 +1,8 @@
-# Copyright (c) 2011, SmartFile <btimby@smartfile.com>
-# All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-#     * Redistributions of source code must retain the above copyright
-#       notice, this list of conditions and the following disclaimer.
-#     * Redistributions in binary form must reproduce the above copyright
-#       notice, this list of conditions and the following disclaimer in the
-#       documentation and/or other materials provided with the distribution.
-#     * Neither the name of the organization nor the
-#       names of its contributors may be used to endorse or promote products
-#       derived from this software without specific prior written permission.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
-# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-import time
+import os
 from libarchive import is_archive, Entry, SeekableArchive
-from tarfile import DEFAULT_FORMAT, USTAR_FORMAT, GNU_FORMAT, PAX_FORMAT, ENCODING
-from tarfile import REGTYPE, AREGTYPE, LNKTYPE, SYMTYPE, DIRTYPE, FIFOTYPE, CONTTYPE, CHRTYPE, BLKTYPE, GNUTYPE_SPARSE
+from tarfile import DEFAULT_FORMAT, USTAR_FORMAT, GNU_FORMAT, PAX_FORMAT, \
+    ENCODING
+from tarfile import REGTYPE, SYMTYPE, DIRTYPE, FIFOTYPE, CHRTYPE, BLKTYPE
 
 FORMAT_CONVERSION = {
     USTAR_FORMAT:       'tar',
@@ -76,7 +52,13 @@ class TarInfo(Entry):
 
 
 class TarFile(SeekableArchive):
-    def __init__(self, name=None, mode='r', fileobj=None, format=DEFAULT_FORMAT, tarinfo=TarInfo, encoding=ENCODING):
+    getmember   = SeekableArchive.getentry
+    list        = SeekableArchive.printlist
+    extract     = SeekableArchive.readpath
+    extractfile = SeekableArchive.readstream
+
+    def __init__(self, name=None, mode='r', fileobj=None,
+                 format=DEFAULT_FORMAT, tarinfo=TarInfo, encoding=ENCODING):
         if name:
             f = name
         elif fileobj:
@@ -85,12 +67,8 @@ class TarFile(SeekableArchive):
             format = FORMAT_CONVERSION.get(format)
         except KeyError:
             raise Exception('Invalid tar format: %s' % format)
-        super(TarFile, self).__init__(f, mode=mode, format=format, entry_class=tarinfo, encoding=encoding)
-
-    getmember   = SeekableArchive.getentry
-    list        = SeekableArchive.printlist
-    extract     = SeekableArchive.readpath
-    extractfile = SeekableArchive.readstream
+        super(TarFile, self).__init__(f, mode=mode, format=format,
+                                      entry_class=tarinfo, encoding=encoding)
 
     def getmembers(self):
         return list(self)
@@ -99,6 +77,7 @@ class TarFile(SeekableArchive):
         return list(self.iterpaths)
 
     def next(self):
+        raise NotImplementedError
         pass # TODO: how to do this?
 
     def extract(self, member, path=None):
@@ -113,10 +92,10 @@ class TarFile(SeekableArchive):
     def add(self, name, arcname, recursive=True, exclude=None, filter=None):
         pass # TODO: implement this.
 
-    def addfile(tarinfo, fileobj):
+    def addfile(self, tarinfo, fileobj):
         return self.writepath(fileobj, tarinfo)
 
-    def gettarinfo(name=None, arcname=None, fileobj=None):
+    def gettarinfo(self, name=None, arcname=None, fileobj=None):
         if name:
             f = name
         elif fileobj:

--- a/libarchive/tar.py
+++ b/libarchive/tar.py
@@ -76,14 +76,14 @@ class TarFile(SeekableArchive):
     def getnames(self):
         return list(self.iterpaths)
 
-    def next(self):
+    def __next__(self):
         raise NotImplementedError
         pass # TODO: how to do this?
 
     def extract(self, member, path=None):
         if path is None:
             path = os.getcwd()
-        if isinstance(member, basestring):
+        if isinstance(member, str):
             f = os.path.join(path, member)
         else:
             f = os.path.join(path, member.pathname)

--- a/libarchive/zip.py
+++ b/libarchive/zip.py
@@ -1,28 +1,3 @@
-# Copyright (c) 2011, SmartFile <btimby@smartfile.com>
-# All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-#     * Redistributions of source code must retain the above copyright
-#       notice, this list of conditions and the following disclaimer.
-#     * Redistributions in binary form must reproduce the above copyright
-#       notice, this list of conditions and the following disclaimer in the
-#       documentation and/or other materials provided with the distribution.
-#     * Neither the name of the organization nor the
-#       names of its contributors may be used to endorse or promote products
-#       derived from this software without specific prior written permission.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
-# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
 import os, time
 from libarchive import is_archive, Entry, SeekableArchive
 from zipfile import ZIP_STORED, ZIP_DEFLATED
@@ -48,7 +23,7 @@ class ZipEntry(Entry):
         return self.size
 
     def set_file_size(self, value):
-        assert isinstance(size, (int, long)), 'Please provide size as int or long.'
+        assert isinstance(value, (int, long)), 'Please provide size as int or long.'
         self.size = value
 
     file_size = property(get_file_size, set_file_size)

--- a/libarchive/zip.py
+++ b/libarchive/zip.py
@@ -23,7 +23,7 @@ class ZipEntry(Entry):
         return self.size
 
     def set_file_size(self, value):
-        assert isinstance(value, (int, long)), 'Please provide size as int or long.'
+        assert isinstance(value, int), 'Please provide size as int or long.'
         self.size = value
 
     file_size = property(get_file_size, set_file_size)

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ versrel = version + '-' + release
 readme = 'README.rst'
 download_url = "http://" + name + ".googlecode.com/files/" + name + "-" + \
                                                           versrel + ".tar.gz"
-long_description = file(readme).read()
+long_description = open(readme).read()
 
 class build_ext_extra(build_ext, object):
     """

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ except ImportError:
 
 
 name = 'python-libarchive'
-version = '3.1.2'
+version = '3.1.3'
 release = '1'
 versrel = version + '-' + release
 readme = 'README.rst'
@@ -81,7 +81,7 @@ if libarchivePrefix:
                                                 environ.get('LDFLAGS', ''))
 else:
     extra_compile_args = []
-    extra_link_args = ['-l:libarchive.so.13.1.2']
+    extra_link_args = ['-l:libarchive.so.13']
 
 __libarchive = Extension(name='libarchive.__libarchive',
                         sources=['libarchive/_libarchive_wrap.c'],

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ except ImportError:
 
 
 name = 'python-libarchive'
-version = '3.1.4'
+version = '4.0.0'
 release = '1'
 versrel = version + '-' + release
 readme = 'README.rst'

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (c) 2011, SmartFile <btimby@smartfile.com>
+# Copyright (c) 2015, SmartFile <tcunningham@smartfile.com>
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -36,7 +36,7 @@ except ImportError:
 
 
 name = 'python-libarchive'
-version = '3.1.3'
+version = '3.1.4'
 release = '1'
 versrel = version + '-' + release
 readme = 'README.rst'
@@ -98,9 +98,9 @@ setup(name = name,
       long_description = long_description,
       license = 'BSD-style license',
       platforms = ['any'],
-      author = 'Ben Timby',
-      author_email = 'btimby at gmail dot com',
-      url = 'http://code.google.com/p/python-libarchive/',
+      author = 'Ben Timby, Travis Cunningham, Ryan Johnston, SmartFile',
+      author_email = 'tcunningham@smartfile.com',
+      url = 'https://github.com/smartfile/python-libarchive',
       download_url = download_url,
       packages = ['libarchive'],
       classifiers = [

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ except ImportError:
 
 
 name = 'python-libarchive'
-version = '4.0.0'
+version = '4.0.1'
 release = '1'
 versrel = version + '-' + release
 readme = 'README.rst'

--- a/tests.py
+++ b/tests.py
@@ -150,10 +150,7 @@ class TestZipRead(unittest.TestCase):
         z = ZipFile(self.f, 'r')
         names = []
         for e in z:
-            if PY3:
-                names.append(e.filename)
-            else:
-                names.append(e.filename[0])
+            names.append(e.filename)
         self.assertEqual(names, FILENAMES, 'File names differ in archive.')
 
     #~ def test_non_ascii(self):

--- a/tests.py
+++ b/tests.py
@@ -175,12 +175,13 @@ class TestZipWrite(unittest.TestCase):
 
         f = file(ZIPPATH, mode='w')
         z = ZipFile(f, 'w')
-        z.writepath(None, '/testdir', folder=True)
+        z.writepath('/home/user/testpath', pathname='/testdir', folder=True)
         z.close()
         f.close()
 
         f = file(ZIPPATH, mode='r')
         z = ZipFile(f, 'r')
+
         assert len(z.entries) == 1
         assert z.entries[0].isdir()
         z.close()

--- a/tests.py
+++ b/tests.py
@@ -47,7 +47,7 @@ FILENAMES = [
 def make_temp_files():
     if not os.path.exists(ZIPPATH):
         for name in FILENAMES:
-            file(os.path.join(TMPDIR, name), 'w').write(''.join(random.sample(string.printable, 10)))
+            open(os.path.join(TMPDIR, name), 'w').write(''.join(random.sample(string.printable, 10)))
 
 
 def make_temp_archive():
@@ -99,7 +99,7 @@ class TestZipRead(unittest.TestCase):
         self.assertEqual(is_zipfile(ZIPPATH), True)
 
     def test_iterate(self):
-        f = file(ZIPPATH, mode='r')
+        f = open(ZIPPATH, mode='r')
         z = ZipFile(f, 'r')
         count = 0
         for e in z:
@@ -108,7 +108,7 @@ class TestZipRead(unittest.TestCase):
 
     def test_deferred_close_by_archive(self):
         """ Test archive deferred close without a stream. """
-        f = file(ZIPPATH, mode='r')
+        f = open(ZIPPATH, mode='r')
         z = ZipFile(f, 'r')
         self.assertIsNotNone(z._a)
         self.assertIsNone(z._stream)
@@ -117,7 +117,7 @@ class TestZipRead(unittest.TestCase):
 
     def test_deferred_close_by_stream(self):
         """ Ensure archive closes self if stream is closed first. """
-        f = file(ZIPPATH, mode='r')
+        f = open(ZIPPATH, mode='r')
         z = ZipFile(f, 'r')
         stream = z.readstream(FILENAMES[0])
         stream.close()
@@ -131,7 +131,7 @@ class TestZipRead(unittest.TestCase):
     def test_close_stream_first(self):
         """ Ensure that archive stays open after being closed if a stream is
         open. Further, ensure closing the stream closes the archive. """
-        f = file(ZIPPATH, mode='r')
+        f = open(ZIPPATH, mode='r')
         z = ZipFile(f, 'r')
         stream = z.readstream(FILENAMES[0])
         z.close()
@@ -146,7 +146,7 @@ class TestZipRead(unittest.TestCase):
         self.assertIsNone(z._stream)
 
     def test_filenames(self):
-        f = file(ZIPPATH, mode='r')
+        f = open(ZIPPATH, mode='r')
         z = ZipFile(f, 'r')
         names = []
         for e in z:
@@ -165,7 +165,7 @@ class TestZipWrite(unittest.TestCase):
         make_temp_files()
 
     def test_writepath(self):
-        f = file(ZIPPATH, mode='w')
+        f = open(ZIPPATH, mode='w')
         z = ZipFile(f, 'w')
         for fname in FILENAMES:
             z.writepath(file(os.path.join(TMPDIR, fname), 'r'))
@@ -174,14 +174,14 @@ class TestZipWrite(unittest.TestCase):
     def test_writepath_directory(self):
         """ Test writing a directory. """
 
-        f = file(ZIPPATH, mode='w')
+        f = open(ZIPPATH, mode='w')
         z = ZipFile(f, 'w')
         z.writepath(None, pathname='/testdir', folder=True)
         z.writepath(None, pathname='/testdir/testinside', folder=True)
         z.close()
         f.close()
 
-        f = file(ZIPPATH, mode='r')
+        f = open(ZIPPATH, mode='r')
         z = ZipFile(f, 'r')
 
         entries = z.infolist()
@@ -192,11 +192,11 @@ class TestZipWrite(unittest.TestCase):
         f.close()
 
     def test_writestream(self):
-        f = file(ZIPPATH, mode='w')
+        f = open(ZIPPATH, mode='w')
         z = ZipFile(f, 'w')
         for fname in FILENAMES:
             full_path = os.path.join(TMPDIR, fname)
-            i = file(full_path)
+            i = open(full_path)
             o = z.writestream(fname)
             while True:
                 data = i.read(1)
@@ -208,11 +208,11 @@ class TestZipWrite(unittest.TestCase):
         z.close()
 
     def test_writestream_unbuffered(self):
-        f = file(ZIPPATH, mode='w')
+        f = open(ZIPPATH, mode='w')
         z = ZipFile(f, 'w')
         for fname in FILENAMES:
             full_path = os.path.join(TMPDIR, fname)
-            i = file(full_path)
+            i = open(full_path)
             o = z.writestream(fname, os.path.getsize(full_path))
             while True:
                 data = i.read(1)
@@ -225,7 +225,7 @@ class TestZipWrite(unittest.TestCase):
 
     def test_deferred_close_by_archive(self):
         """ Test archive deferred close without a stream. """
-        f = file(ZIPPATH, mode='w')
+        f = open(ZIPPATH, mode='w')
         z = ZipFile(f, 'w')
         o = z.writestream(FILENAMES[0])
         z.close()

--- a/tests.py
+++ b/tests.py
@@ -170,6 +170,22 @@ class TestZipWrite(unittest.TestCase):
             z.writepath(file(os.path.join(TMPDIR, fname), 'r'))
         z.close()
 
+    def test_writepath_directory(self):
+        """ Test writing a directory. """
+
+        f = file(ZIPPATH, mode='w')
+        z = ZipFile(f, 'w')
+        z.writepath(None, '/testdir', folder=True)
+        z.close()
+        f.close()
+
+        f = file(ZIPPATH, mode='r')
+        z = ZipFile(f, 'r')
+        assert len(z.entries) == 1
+        assert z.entries[0].isdir()
+        z.close()
+        f.close()
+
     def test_writestream(self):
         f = file(ZIPPATH, mode='w')
         z = ZipFile(f, 'w')

--- a/tests.py
+++ b/tests.py
@@ -33,7 +33,7 @@ from libarchive.zip import is_zipfile, ZipFile, ZipEntry
 
 PY3 = sys.version_info[0] == 3
 
-TMPDIR = tempfile.mkdtemp()
+TMPDIR = tempfile.mkdtemp(suffix='.python-libarchive')
 ZIPCMD = '/usr/bin/zip'
 ZIPFILE = 'test.zip'
 ZIPPATH = os.path.join(TMPDIR, ZIPFILE)

--- a/tests.py
+++ b/tests.py
@@ -26,7 +26,8 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import os, unittest, tempfile, random, string, subprocess, sys
+import os, unittest, tempfile, random, string, sys
+import zipfile
 
 from libarchive import is_archive_name, is_archive
 from libarchive.zip import is_zipfile, ZipFile, ZipEntry
@@ -34,7 +35,6 @@ from libarchive.zip import is_zipfile, ZipFile, ZipEntry
 PY3 = sys.version_info[0] == 3
 
 TMPDIR = tempfile.mkdtemp(suffix='.python-libarchive')
-ZIPCMD = '/usr/bin/zip'
 ZIPFILE = 'test.zip'
 ZIPPATH = os.path.join(TMPDIR, ZIPFILE)
 
@@ -54,13 +54,10 @@ def make_temp_files():
 
 
 def make_temp_archive():
-    if not os.access(ZIPCMD, os.X_OK):
-        raise AssertionError('Cannot execute %s.' % ZIPCMD)
-    cmd = [ZIPCMD, ZIPFILE]
     make_temp_files()
-    cmd.extend(FILENAMES)
-    os.chdir(TMPDIR)
-    subprocess.call(cmd, stdout=subprocess.PIPE)
+    with zipfile.ZipFile(ZIPPATH, mode="w") as z:
+        for name in FILENAMES:
+            z.write(os.path.join(TMPDIR, name), arcname=name)
 
 
 class TestIsArchiveName(unittest.TestCase):

--- a/tests.py
+++ b/tests.py
@@ -43,11 +43,12 @@ FILENAMES = [
     #'álért.txt',
 ]
 
+
 def make_temp_files():
-    print TMPDIR
     if not os.path.exists(ZIPPATH):
         for name in FILENAMES:
             file(os.path.join(TMPDIR, name), 'w').write(''.join(random.sample(string.printable, 10)))
+
 
 def make_temp_archive():
     if not os.access(ZIPCMD, os.X_OK):
@@ -56,7 +57,7 @@ def make_temp_archive():
     make_temp_files()
     cmd.extend(FILENAMES)
     os.chdir(TMPDIR)
-    subprocess.call(cmd)
+    subprocess.call(cmd, stdout=subprocess.PIPE)
 
 
 class TestIsArchiveName(unittest.TestCase):
@@ -175,15 +176,18 @@ class TestZipWrite(unittest.TestCase):
 
         f = file(ZIPPATH, mode='w')
         z = ZipFile(f, 'w')
-        z.writepath('/home/user/testpath', pathname='/testdir', folder=True)
+        z.writepath(None, pathname='/testdir', folder=True)
+        z.writepath(None, pathname='/testdir/testinside', folder=True)
         z.close()
         f.close()
 
         f = file(ZIPPATH, mode='r')
         z = ZipFile(f, 'r')
 
-        assert len(z.entries) == 1
-        assert z.entries[0].isdir()
+        entries = z.infolist()
+
+        assert len(entries) == 2
+        assert entries[0].isdir()
         z.close()
         f.close()
 


### PR DESCRIPTION
I assume that was the originally intended behaviour.
This way it creates directory to which archive's entry will be extracted.
Otherwise it will just create empty files that later remain unused.

It's pretty self explanatory but here's an example:
```python
❯ ls
archive.cpio  output
❯ cpio -it < archive.cpio 
postinstall.sh
sw-description
uImage-kernel-5.1.7-dtb-imx6q-dss11e.bin
8428 blocks
❯ python3.8
Python 3.8.3 (default, May 15 2020, 00:00:00) 
[GCC 10.1.1 20200507 (Red Hat 10.1.1-1)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import os, libarchive
>>> with libarchive.Archive("archive.cpio", "r", format="cpio") as archive:
...     for entry in archive:
...             archive.readpath(os.path.join("./output/", entry.pathname))
... 
0
0
0
>>> 
❯ ls # as visible here: additional directory was created for each entry,
# extraction is fine but superfluous directories are there
archive.cpio  postinstall.sh  uImage-kernel-5.1.7-dtb-imx6q-dss11e.bin
output        sw-description
```